### PR TITLE
Improve dropdown and graph styles

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -30,6 +30,20 @@ h1, h2, h3 {
     border: 1px solid #00ffe1 !important;
 }
 
+/* Estilos para las opciones del dropdown en tema oscuro */
+.Select-menu-outer {
+    background-color: #1c1c1c !important;
+    color: #fff !important;
+    border: 1px solid #00ffe1 !important;
+}
+.Select-option.is-focused, .Select-option.is-selected {
+    background-color: #00ffe1 !important;
+    color: #000 !important;
+}
+.Select-value, .Select-placeholder {
+    color: #fff !important;
+}
+
 .card:hover {
     transform: scale(1.02);
     box-shadow: 0 0 20px #00ffe1;

--- a/callbacks/filters.py
+++ b/callbacks/filters.py
@@ -35,12 +35,20 @@ def register_callbacks(app):
         if rango_edad:
             df = df[(df["edad_paciente"] >= rango_edad[0]) & (df["edad_paciente"] <= rango_edad[1])]
 
+        dark_theme = dict(
+            template="plotly_dark",
+            paper_bgcolor="#1c1c1c",
+            plot_bgcolor="#1c1c1c",
+            font_color="#ffffff",
+        )
+
         fig_modalidad = px.pie(
             modalidad_consultas(df),
             values=modalidad_consultas(df).values,
             names=modalidad_consultas(df).index,
             title="Distribución por modalidad"
         )
+        fig_modalidad.update_layout(**dark_theme)
 
         top_especialidades = especialidades_top(df)
         fig_especialidades = px.bar(
@@ -50,6 +58,7 @@ def register_callbacks(app):
             labels={"x": "Especialidad", "y": "Cantidad"},
             title="Especialidades más consultadas"
         )
+        fig_especialidades.update_layout(**dark_theme)
 
         genero_counts = df["genero_paciente"].value_counts()
         fig_genero = px.pie(
@@ -58,6 +67,7 @@ def register_callbacks(app):
             names=genero_counts.index,
             title="Distribución por género"
         )
+        fig_genero.update_layout(**dark_theme)
 
         fig_edad = px.histogram(
             df,
@@ -65,6 +75,7 @@ def register_callbacks(app):
             nbins=20,
             title="Distribución por edad"
         )
+        fig_edad.update_layout(**dark_theme)
 
         fig_duracion = px.histogram(
             df,
@@ -72,6 +83,7 @@ def register_callbacks(app):
             nbins=20,
             title="Duración de consultas"
         )
+        fig_duracion.update_layout(**dark_theme)
 
         mapa_html = generar_mapa_consultas(df)
 

--- a/components/cards.py
+++ b/components/cards.py
@@ -50,11 +50,26 @@ def filter_controls():
 def graph_tabs():
     return dbc.Row([
         dcc.Tabs(id="tabs-graficos", value="tab-modalidad", children=[
-            dcc.Tab(label="Modalidad", children=[dcc.Graph(id="grafico-modalidad")]),
-            dcc.Tab(label="Especialidades", children=[dcc.Graph(id="grafico-especialidades")]),
-            dcc.Tab(label="Género", children=[dcc.Graph(id="grafico-genero")]),
-            dcc.Tab(label="Edad", children=[dcc.Graph(id="grafico-edad")]),
-            dcc.Tab(label="Duración", children=[dcc.Graph(id="grafico-duracion")]),
+            dcc.Tab(label="Modalidad", children=[
+                html.P("Distribución de consultas por modalidad", className="text-light"),
+                dcc.Graph(id="grafico-modalidad")
+            ]),
+            dcc.Tab(label="Especialidades", children=[
+                html.P("Especialidades más consultadas", className="text-light"),
+                dcc.Graph(id="grafico-especialidades")
+            ]),
+            dcc.Tab(label="Género", children=[
+                html.P("Distribución de pacientes por género", className="text-light"),
+                dcc.Graph(id="grafico-genero")
+            ]),
+            dcc.Tab(label="Edad", children=[
+                html.P("Distribución de pacientes por edad", className="text-light"),
+                dcc.Graph(id="grafico-edad")
+            ]),
+            dcc.Tab(label="Duración", children=[
+                html.P("Duración de las consultas", className="text-light"),
+                dcc.Graph(id="grafico-duracion")
+            ]),
         ])
     ], className="mb-4")
 


### PR DESCRIPTION
## Summary
- refine dropdown dark theme in `assets/style.css`
- add explanations above graphs in `graph_tabs`
- set dark layout for all figures in callbacks

## Testing
- `python -m py_compile app.py components/cards.py callbacks/filters.py`

------
https://chatgpt.com/codex/tasks/task_e_687025ccb984832d85e5d543cb6c62a3